### PR TITLE
Revert "Bump sphinx from 3.5.4 to 4.0.2 in /docs"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==4.0.2
+Sphinx==3.5.4
 sphinx-rtd-theme==0.5.2
 myst-parser==0.14.0


### PR DESCRIPTION
Reverts mario33881/betterSIS#7

MyST-Parser does not support Sphinx 4 (for now)