### PR TITLE
Add AppImage support

### DIFF
--- a/.github/workflows/appimage_builder.yml
+++ b/.github/workflows/appimage_builder.yml
@@ -1,0 +1,27 @@
+name: Builder
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: macos-10.15
+
+    steps:
+    - uses: actions/checkout@v2.3.4
+
+    - name: Build AppImage version
+      run: |
+        cd appimage
+        vagrant up
+        vagrant halt
+        cd ..
+    
+    - name: Archive AppImage version
+      uses: actions/upload-artifact@v2
+      with:
+        name: appimage_files
+        path: |
+          BetterSIS-*-x86_64.AppImage
+          BetterSIS-*-x86_64.AppImage.zsync

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dist/
 
 *.egg-info/
 *.snap
+
+*.AppImage
+*.zsync

--- a/appimage/Vagrantfile
+++ b/appimage/Vagrantfile
@@ -1,0 +1,72 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "../.", "/src"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+  config.vm.provision :shell, path: "build.sh", run: 'always'
+
+end

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+IFS=$'\n\t'
+
+app_name="BetterSIS"
+app_comment="The modern shell for SIS (the circuit simulator and optimizer)"
+terminal="true"
+categories="Development;Science;Utility;"
+pip_app_name="bettersis"
+icon_name="bettersis"
+icon_url="https://raw.githubusercontent.com/mario33881/betterSIS/64bf89345c4e5465d60828b4c8d54ffe9e2cb9bb/_static/images/logo.svg"
+architecture="x86_64"
+python_version="python3.8"
+python_full_version="${python_version}.11"
+python_short_version="cp38"
+svg="0" # 0: true (uses inkscape for svg -> png), 1: false
+
+SCRIPTPATH="$( cd "$( dirname "$0" )" || exit ; pwd -P )"  # percorso questo script
+SCRIPTDIR=$( basename "$SCRIPTPATH" )
+
+sudo apt-get install -y wget
+
+# download appimage
+wget https://github.com/niess/python-appimage/releases/download/${python_version}/${python_full_version}-${python_short_version}-${python_short_version}-manylinux1_${architecture}.AppImage
+
+# give permission to execute and extract the appimage
+chmod +x python*-manylinux1_${architecture}.AppImage
+./python*-manylinux1_${architecture}.AppImage --appimage-extract
+
+# install using pip
+./squashfs-root/AppRun -m pip install https://github.com/mario33881/betterSIS/archive/refs/heads/main.zip --no-cache-dir
+
+# Change AppRun so that it launches bettersis
+sed -i -e "s|/opt/${python_version}/bin/${python_version}|/usr/bin/${pip_app_name}|g" ./squashfs-root/AppRun
+
+# Edit the desktop file
+mv squashfs-root/usr/share/applications/python*.desktop squashfs-root/usr/share/applications/bettersis.desktop
+sed -i -e "s|^Name=.*|Name=${app_name}|g" squashfs-root/usr/share/applications/*.desktop
+sed -i -e "s|^Exec=.*|Exec=${pip_app_name}|g" squashfs-root/usr/share/applications/*.desktop
+sed -i -e "s|^Icon=.*|Icon=${icon_name}|g" squashfs-root/usr/share/applications/*.desktop
+sed -i -e "s|^Comment=.*|Comment=${app_comment}|g" squashfs-root/usr/share/applications/*.desktop
+sed -i -e "s|^Terminal=.*|Terminal=${terminal}|g" squashfs-root/usr/share/applications/*.desktop
+sed -i -e "s|^Categories=.*|Categories=${categories}|g" squashfs-root/usr/share/applications/*.desktop
+rm squashfs-root/*.desktop
+cp squashfs-root/usr/share/applications/*.desktop squashfs-root/
+
+# Add icon
+mkdir -p squashfs-root/usr/share/icons/hicolor/128x128/apps/
+
+if [ "$svg" = "0" ] ; then
+    sudo apt-get install inkscape -y
+    wget $icon_url -O $icon_name.svg
+    inkscape --export-type="png" -w 128 -h 128 $icon_name.svg -o squashfs-root/usr/share/icons/hicolor/128x128/apps/$icon_name.png
+else
+    sudo apt-get install imagemagick -y
+    wget $icon_url -O $icon_name.png
+    convert -resize 128x128 $icon_name.png squashfs-root/usr/share/icons/hicolor/128x128/apps/$icon_name.png
+fi
+
+cp squashfs-root/usr/share/icons/hicolor/128x128/apps/$icon_name.png squashfs-root/
+
+# Add AppImageUpdate inside the AppImage itself
+wget https://github.com/AppImage/AppImageUpdate/releases/download/continuous/AppImageUpdate-x86_64.AppImage -O squashfs-root/appimageupdate.AppImage
+chmod +x squashfs-root/appimageupdate.AppImage
+
+cd squashfs-root
+./appimageupdate.AppImage --appimage-extract
+mv ./squashfs-root ./appimageupdate
+rm -rf appimageupdate.AppImage
+cd ..
+
+# TODO: try to trim files from the image to reduce size of appimage
+
+
+# Convert back into an AppImage
+export VERSION=$(cat squashfs-root/opt/python*/lib/python*/site-packages/$pip_app_name-*.dist-info/METADATA | grep "^Version:.*" | cut -d " " -f 2)
+sudo apt install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace fuse
+sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+sudo chmod +x /usr/local/bin/appimagetool
+
+export ARCH=$architecture
+appimagetool ./squashfs-root/ --sign -u "gh-releases-zsync|mario33881|betterSIS|latest|BetterSIS-*x86_64.AppImage.zsync"

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 set -x
 IFS=$'\n\t'
 
+if [ "$(logname)" = "vagrant" ]; then
+    ls
+    rm -rf /home/vagrant/*
+fi
+
 app_name="BetterSIS"
 app_comment="The modern shell for SIS (the circuit simulator and optimizer)"
 terminal="true"
@@ -81,9 +86,14 @@ cd ..
 
 # Convert back into an AppImage
 export VERSION=$(cat squashfs-root/opt/python*/lib/python*/site-packages/$pip_app_name-*.dist-info/METADATA | grep "^Version:.*" | cut -d " " -f 2)
-#sudo apt install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace fuse
+sudo apt install -y fuse
 sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
 sudo chmod +x /usr/local/bin/appimagetool
 
 export ARCH=$architecture
-appimagetool ./squashfs-root/ --sign -u "gh-releases-zsync|mario33881|betterSIS|latest|BetterSIS-*x86_64.AppImage.zsync"
+appimagetool ./squashfs-root/ -u "gh-releases-zsync|mario33881|betterSIS|latest|BetterSIS-*x86_64.AppImage.zsync"
+
+if [ "$(logname)" = "vagrant" ]; then
+    ls
+    cp BetterSIS-*x86_64.AppImage* /src/.
+fi

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -51,7 +51,13 @@ mkdir -p squashfs-root/usr/share/icons/hicolor/128x128/apps/
 if [ "$svg" = "0" ] ; then
     sudo apt-get install inkscape -y
     wget $icon_url -O $icon_name.svg
+
+    set +euo pipefail
     inkscape --export-type="png" -w 128 -h 128 $icon_name.svg -o squashfs-root/usr/share/icons/hicolor/128x128/apps/$icon_name.png
+    if [ "$?" != "0" ] ; then
+        set -euo pipefail
+        inkscape -z -w 128 -h 128 $icon_name.svg -e squashfs-root/usr/share/icons/hicolor/128x128/apps/$icon_name.png
+    fi
 else
     sudo apt-get install imagemagick -y
     wget $icon_url -O $icon_name.png
@@ -75,7 +81,7 @@ cd ..
 
 # Convert back into an AppImage
 export VERSION=$(cat squashfs-root/opt/python*/lib/python*/site-packages/$pip_app_name-*.dist-info/METADATA | grep "^Version:.*" | cut -d " " -f 2)
-sudo apt install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace fuse
+#sudo apt install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace fuse
 sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
 sudo chmod +x /usr/local/bin/appimagetool
 

--- a/bettersis/bettersis.py
+++ b/bettersis/bettersis.py
@@ -407,6 +407,10 @@ class Bettersis:
                                               "(with no parameters) AFTER using the read_blif command"))
                     self.lastcmd_success = False
 
+        # bsis_update command
+        elif t_command == "bsis_update" and os.getenv("APPIMAGE") and os.getenv("APPDIR"):
+            self.lastcmd_success = update_checker.update_appimage()
+
         # help command
         elif t_command == "help":
             print("\nSIS COMMANDS:")
@@ -422,6 +426,10 @@ class Bettersis:
             print("* bsis_checkblif : BLIF parser/validation tool")
             print("* bsis_script : executes optimization and mapping commands in one command "
                   "(needs parameters to specify the type of circuit to optimize/map)")
+
+            if os.getenv("APPIMAGE") and os.getenv("APPDIR"):
+                # Running inside AppImage: show that you can update the AppImage
+                print("* bsis_update: download the latest version (as an AppImage)")
 
             print("\n> If you would like to know more about these commands, "
                   "execute the 'bsis_documentation' command to open the documentation website")
@@ -457,23 +465,23 @@ class Bettersis:
         """
         if t_path == "":
             # show files and directories inside the current folder
-            print_formatted_text(HTML("<orange>(F)iles</orange> and <blue>(D)irectories</blue> inside '" + os.getcwd() + "'"))
+            print_formatted_text(HTML("<orange>(F)iles</orange> and <DeepSkyBlue>(D)irectories</DeepSkyBlue> inside '" + os.getcwd() + "'"))
             print("-" * 50)
             self.lastcmd_success = True
             for el in os.listdir():
                 if os.path.isdir(el):
-                    print_formatted_text(HTML("<blue>(D) " + el + "</blue>"))
+                    print_formatted_text(HTML("<DeepSkyBlue>(D) " + el + "</DeepSkyBlue>"))
                 else:
                     print_formatted_text(HTML("<orange>(F) " + el + "</orange>"))
 
         elif os.path.isdir(t_path):
             # show files and directories inside the specified folder
-            print_formatted_text(HTML("<orange>(F)iles</orange> and <blue>(D)irectories</blue> inside '" + t_path + "'"))
+            print_formatted_text(HTML("<orange>(F)iles</orange> and <DeepSkyBlue>(D)irectories</DeepSkyBlue> inside '" + t_path + "'"))
             print("-" * 50)
             self.lastcmd_success = True
             for el in os.listdir(t_path):
                 if os.path.isdir(el):
-                    print_formatted_text(HTML("<blue>(D) " + el + "</blue>"))
+                    print_formatted_text(HTML("<DeepSkyBlue>(D) " + el + "</DeepSkyBlue>"))
                 else:
                     print_formatted_text(HTML("<orange>(F) " + el + "</orange>"))
         else:
@@ -582,6 +590,10 @@ def main():
     logger.info("[PLATFORM] Using OS: %s" % platform.platform())
     logger.info("[PLATFORM] OS version: %s" % platform.version())
     logger.info("[PLATFORM] Python version: %s" % platform.python_version())
+
+    if os.getenv("APPIMAGE") and os.getenv("APPDIR"):
+        # Running inside AppImage: allow the user to update the image
+        bettersis_cmds.append("bsis_update")
 
     bettersis = None
 

--- a/bettersis/bettersis.py
+++ b/bettersis/bettersis.py
@@ -465,7 +465,9 @@ class Bettersis:
         """
         if t_path == "":
             # show files and directories inside the current folder
-            print_formatted_text(HTML("<orange>(F)iles</orange> and <DeepSkyBlue>(D)irectories</DeepSkyBlue> inside '" + os.getcwd() + "'"))
+            print_formatted_text(HTML("<orange>(F)iles</orange> and "
+                                      "<DeepSkyBlue>(D)irectories</DeepSkyBlue> "
+                                      "inside '" + os.getcwd() + "'"))
             print("-" * 50)
             self.lastcmd_success = True
             for el in os.listdir():
@@ -476,7 +478,9 @@ class Bettersis:
 
         elif os.path.isdir(t_path):
             # show files and directories inside the specified folder
-            print_formatted_text(HTML("<orange>(F)iles</orange> and <DeepSkyBlue>(D)irectories</DeepSkyBlue> inside '" + t_path + "'"))
+            print_formatted_text(HTML("<orange>(F)iles</orange> and "
+                                      "<DeepSkyBlue>(D)irectories</DeepSkyBlue> "
+                                      "inside '" + t_path + "'"))
             print("-" * 50)
             self.lastcmd_success = True
             for el in os.listdir(t_path):

--- a/bettersis/siscompleter.py
+++ b/bettersis/siscompleter.py
@@ -211,7 +211,7 @@ def get_siscompleter():
 
     :return prompt_toolkit.completion.nested.NestedCompleter siscompleter: contains SIS commands with their parameters
     """
-    siscompleter = NestedCompleter.from_nested_dict({
+    commands = {
         "act_map": get_act_map_params(),
         "add_inverter": None,
         "alias": None,
@@ -391,7 +391,13 @@ def get_siscompleter():
         "bsis_documentation": None,
         "bsis_releases": None,
         "bsis_checkblif": get_files()
-    })
+    }
+
+    if os.getenv("APPIMAGE") and os.getenv("APPDIR"):
+        # running inside an AppImage
+        commands["bsis_update"] = None
+
+    siscompleter = NestedCompleter.from_nested_dict(commands)
 
     return siscompleter
 

--- a/bettersis/update_checker.py
+++ b/bettersis/update_checker.py
@@ -141,10 +141,10 @@ def check_updates(t_ghreleases_apiurl, t_version):  # noqa: C901
     return res
 
 
-def update_appimage():
+def update_appimage():  # noqa: C901
     """
     If this function was run in an appimage and there are updates,
-    download the latest AppImage and ask the user if they want to 
+    download the latest AppImage and ask the user if they want to
     delete old versions (if present).
 
     :return bool success: True if the check for updates was successful
@@ -160,7 +160,7 @@ def update_appimage():
                     subprocess.call([aiut_path, os.environ["APPIMAGE"]])
                 else:
                     print("Already using latest version. No new updates found.")
-                
+
                 success = True
 
                 found_old_version = False
@@ -175,23 +175,23 @@ def update_appimage():
                             while user_input not in ["y", "n"]:
                                 user_input = input("Found an/many old AppImage(s): do you want to delete it? [y/n]: ")
                                 user_input.strip().lower()
-                            
+
                             if user_input == "y":
                                 wants_delete = True
-                        
+
                         if wants_delete and os.path.isfile(version_path):
                             os.remove(version_path)
-                        
+
                         if wants_delete and os.path.isfile(version_path + ".zs-old"):
                             os.remove(version_path + ".zs-old")
             else:
                 print("Couldn't get releases data")
         else:
             print("Can't check for updates: it looks like you are not running the AppImage version")
-        
+
     except Exception as e:
         print("Something went wrong during the update:", e)
-    
+
     return success
 
 


### PR DESCRIPTION
adds AppImage support:
* its like using the PyInstaller version but with updates
* if the currently running version is an AppImage use the ```bsis_update``` command to download the latest version
* Build AppImages using a mac OS instance that executes vagrant
  > Mac OS instances are the only ones where nested virtualization is enabled

Not related to AppImages:
* use DeepSkyBlue instead of Blue for directories: blue is hard to read on black terminals