### PR TITLE
Revert "Bump sphinx from 4.5.0 to 5.0.0 in /docs"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==5.0.0
+Sphinx==4.5.0
 sphinx-rtd-theme==1.0.0
 myst-parser==0.17.2


### PR DESCRIPTION
Reverts mario33881/betterSIS#66

pip conflict:
```
The user requested Sphinx==5.0.0
sphinx-rtd-theme 1.0.0 depends on sphinx>=1.6
myst-parser 0.17.2 depends on sphinx<5 and >=3.1
```