### PR TITLE
Revert "Bump sphinx from 6.2.1 to 7.0.0 in /docs"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==7.0.0
+Sphinx==6.2.1
 sphinx-rtd-theme==1.2.0
 myst-parser==1.0.0


### PR DESCRIPTION
Reverts mario33881/betterSIS#122: sphinx-rtd-theme 1.2.0 depends on sphinx<7